### PR TITLE
Show simpler BOM configuration with Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then add the dependencies you need without specifying the version:
 
 ## Getting Started - Gradle
 
-For usage with [Gradle](https://gradle.org/), apply the `dependency-management-plugin` plugin like so:
+For usage with **[Gradle](https://gradle.org/) up to version 4.x**, apply the `dependency-management-plugin` plugin like so:
 
 ```groovy
 buildscript {
@@ -105,6 +105,12 @@ dependencies {
     compile 'org.axonframework.extensions.mongo:axon-mongo'
     ...
 }
+```
+
+Beginning with **[Gradle version 5.0](https://docs.gradle.org/5.0/userguide/managing_transitive_dependencies.html#sec:bom_import)**, you can also omit the dependency-management plugin and instead use the `platform` dependency dsl to import maven boms:
+
+```
+implementation(platform("org.axonframework:axon-bom:<VERSION>"))
 ```
 
 ## Receiving help


### PR DESCRIPTION
Using  the dependency management plugin to import BOM has not been required for quite a while, with 5.0 gralde introduced a greatly improved dependency handling that allows importing BOMs directly. 
Most docs on the internet still feature the "legacy" approach, let's change that and unleash the full power of gradle.