### PR TITLE
Fix sonatype deploy error for forked pull requests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,15 @@ jobs:
             ${{ runner.os }}-maven
 
 
-      - name: Build and deploy to Sonatype
+      - name: Build
+        run: |
+          mvn -B -U verify -DskipTests=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Deploy to Sonatype
+        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
+        if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           mvn -B -U deploy -DskipTests=true
         env:


### PR DESCRIPTION
It should prevent the deploy operation when PRs are coming from non-axoniq users.