### PR TITLE
Added a large number of external dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,25 @@
         <axonserver-plugin-api.version>4.5</axonserver-plugin-api.version>
 
         <projectreactor.version>3.4.16</projectreactor.version>
+        <projectreactor.version>3.4.15</projectreactor.version>
+        <grpc.version>1.43.0</grpc.version>
+        <spring-boot.version>2.6.4</spring-boot.version>
+        <spring.version>5.3.16</spring.version>
+        <spring-rabbit.version>2.4.2</spring-rabbit.version>
+        <spring-cloud.version>3.1.1</spring-cloud.version>
+        <jackson.version>2.13.1</jackson.version>
+        <xstream.version>1.4.18</xstream.version>
+        <quartz.version>2.3.2</quartz.version>
+        <opentracing-spring-tracer.version>0.4.0</opentracing-spring-tracer.version>
+        <opentracing-spring-jaeger.version>3.3.1</opentracing-spring-jaeger.version>
+        <dropwizard.version>4.2.8</dropwizard.version>
+        <micrometer.version>1.8.3</micrometer.version>
+        <kafka-clients.version>3.1.0</kafka-clients.version>
+        <amqp-client.version>5.14.2</amqp-client.version>
+        <mongo.version>4.5.0</mongo.version>
+        <jgroups.version>4.2.1.Final</jgroups.version>
+        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin-logging-jvm.version>2.1.21</kotlin-logging-jvm.version>
     </properties>
 
     <dependencyManagement>
@@ -66,6 +85,21 @@
                 <groupId>io.axoniq</groupId>
                 <artifactId>axonserver-connector-java</artifactId>
                 <version>${axonserver-connector-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-stub</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty</artifactId>
+                <version>${grpc.version}</version>
             </dependency>
             <!-- Axon Server - Plugins -->
             <dependency>
@@ -139,6 +173,92 @@
                 <artifactId>axon-test</artifactId>
                 <version>${axon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>${xstream.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz</artifactId>
+                <version>${quartz.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <!-- Do we want these in here as well? -->
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>2.0.1.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.persistence</groupId>
+                <artifactId>javax.persistence-api</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-entitymanager</artifactId>
+                <version>5.6.5.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.ehcache</groupId>
+                <artifactId>ehcache</artifactId>
+                <version>2.10.9.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>2.1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>xom</groupId>
+                <artifactId>xom</artifactId>
+                <version>1.3.7</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lmax</groupId>
+                <artifactId>disruptor</artifactId>
+                <version>3.4.4</version>
+            </dependency>
             <!-- Extension - AMQP -->
             <dependency>
                 <groupId>org.axonframework.extensions.amqp</groupId>
@@ -154,6 +274,21 @@
                 <groupId>org.axonframework.extensions.amqp</groupId>
                 <artifactId>axon-amqp-spring-boot-starter</artifactId>
                 <version>${extension.amqp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.rabbitmq</groupId>
+                <artifactId>amqp-client</artifactId>
+                <version>${amqp-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.amqp</groupId>
+                <artifactId>spring-rabbit</artifactId>
+                <version>${spring-rabbit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-amqp</artifactId>
+                <version>${spring-boot.version}</version>
             </dependency>
             <!-- Extension - CDI -->
             <dependency>
@@ -177,6 +312,11 @@
                 <artifactId>axon-jgroups-spring-boot-starter</artifactId>
                 <version>${extension.jgroups.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jgroups</groupId>
+                <artifactId>jgroups</artifactId>
+                <version>${jgroups.version}</version>
+            </dependency>
             <!-- Extension - Kafka -->
             <dependency>
                 <groupId>org.axonframework.extensions.kafka</groupId>
@@ -193,17 +333,47 @@
                 <artifactId>axon-kafka-spring-boot-starter</artifactId>
                 <version>${extension.kafka.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka-clients.version}</version>
+            </dependency>
             <!-- Extension - Kotlin -->
             <dependency>
                 <groupId>org.axonframework.extensions.kotlin</groupId>
                 <artifactId>axon-kotlin</artifactId>
                 <version>${extension.kotlin.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-kotlin</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <!-- Extension - Mongo -->
             <dependency>
                 <groupId>org.axonframework.extensions.mongo</groupId>
                 <artifactId>axon-mongo</artifactId>
                 <version>${extension.mongo.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-sync</artifactId>
+                <version>${mongo.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.microutils</groupId>
+                <artifactId>kotlin-logging-jvm</artifactId>
+                <version>${kotlin-logging-jvm.version}</version>
             </dependency>
             <!-- Extension - Reactor -->
             <dependency>
@@ -221,7 +391,6 @@
                 <artifactId>axon-reactor-spring-boot-starter</artifactId>
                 <version>${extension.reactor.version}</version>
             </dependency>
-            <!-- Project reactor - Included to avoid compatability issues when updating from older Axon versions -->
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
@@ -243,6 +412,11 @@
                 <artifactId>axon-springcloud-spring-boot-starter</artifactId>
                 <version>${extension.springcloud.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-commons</artifactId>
+                <version>${spring-cloud.version}</version>
+            </dependency>
             <!-- Extension - Tracing -->
             <dependency>
                 <groupId>org.axonframework.extensions.tracing</groupId>
@@ -258,6 +432,77 @@
                 <groupId>org.axonframework.extensions.tracing</groupId>
                 <artifactId>axon-tracing-spring-boot-starter</artifactId>
                 <version>${extension.tracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+                <version>${opentracing-spring-tracer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+                <version>${opentracing-spring-jaeger.version}</version>
+            </dependency>
+            <!-- Spring Dependencies -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-validation</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-data-jpa</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-autoconfigure</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context-support</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-messaging</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-orm</artifactId>
+                <version>${spring.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Added a large number of external dependencies used by axon framework and extensions to prevent mismatches with incompatible versions.

This is a follow-up of adding the reactor dependency to the bom in https://github.com/AxonFramework/axon-bom/pull/43

I have added a (very) large number of additional dependencies, which are all used by the Axon Framework and/or the various extensions. However, there a couple of points for discussion:

1. To what extent do we want to add these other dependecies? I have added just about everything I could see as a candidate for now, but believe that, especially for framework, we may not want to include all of these dependencies (see comment in pom.xml for the most dubious dependencies IMO) and limit this to those that are most likely to end up with version mismatches and related issues.
2. Instead of limiting this list, we may want to consider offering two versions of the bom as an alternative, one with just the base Axon dependencies (`axon-bom`), and another with all the secondary dependencies included as well (`axon-bom-extended` or something similar). Personally I don't have any strong preference here.

Based on the conclusions we might draw form the above points, we'll have to revisit/cleanup this pom a bit as well, especially versions through variables vs plain versions using the `<version>` tag without referencing a variable.