### PR TITLE
Upgrade Axon dependencies to 4.7.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,6 @@
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
-                <artifactId>axon-configuration-jakarta</artifactId>
-                <version>${axon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.axonframework</groupId>
                 <artifactId>axon-disruptor</artifactId>
                 <version>${axon.version}</version>
             </dependency>
@@ -106,22 +101,12 @@
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
-                <artifactId>axon-eventsourcing-jakarta</artifactId>
-                <version>${axon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.axonframework</groupId>
                 <artifactId>axon-legacy</artifactId>
                 <version>${axon.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-messaging</artifactId>
-                <version>${axon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.axonframework</groupId>
-                <artifactId>axon-messaging-jakarta</artifactId>
                 <version>${axon.version}</version>
             </dependency>
             <dependency>
@@ -137,11 +122,6 @@
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-modelling</artifactId>
-                <version>${axon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.axonframework</groupId>
-                <artifactId>axon-modelling-jakarta</artifactId>
                 <version>${axon.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,17 +45,17 @@
         <axon.version>4.6.3</axon.version>
         <axonserver-plugin-api.version>4.6.0</axonserver-plugin-api.version>
 
-        <extension.amqp.version>4.6.0</extension.amqp.version>
+        <extension.amqp.version>4.7.1</extension.amqp.version>
         <extension.cdi.version>4.5-alpha1</extension.cdi.version>
-        <extension.jgroups.version>4.6.0</extension.jgroups.version>
-        <extension.kafka.version>4.6.0</extension.kafka.version>
-        <extension.kotlin.version>4.6.0</extension.kotlin.version>
-        <extension.mongo.version>4.6.0</extension.mongo.version>
-        <extension.multitenancy.version>4.6.2</extension.multitenancy.version>
-        <extension.reactor.version>4.6.0</extension.reactor.version>
+        <extension.jgroups.version>4.7.0</extension.jgroups.version>
+        <extension.kafka.version>4.7.0</extension.kafka.version>
+        <extension.kotlin.version>4.7.0</extension.kotlin.version>
+        <extension.mongo.version>4.7.0</extension.mongo.version>
+        <extension.multitenancy.version>4.7.0</extension.multitenancy.version>
+        <extension.reactor.version>4.7.0</extension.reactor.version>
         <extension.spring-native.version>0.1.0</extension.spring-native.version>
-        <extension.springcloud.version>4.6.0</extension.springcloud.version>
-        <extension.tracing.version>4.6.1</extension.tracing.version>
+        <extension.springcloud.version>4.7.0</extension.springcloud.version>
+        <extension.tracing.version>4.7.0</extension.tracing.version>
 
         <projectreactor.version>3.5.2</projectreactor.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <axonserver-connector-java.version>4.6.2</axonserver-connector-java.version>
-        <axon.version>4.6.3</axon.version>
+        <axon.version>4.7.1</axon.version>
         <axonserver-plugin-api.version>4.6.0</axonserver-plugin-api.version>
 
         <extension.amqp.version>4.7.1</extension.amqp.version>


### PR DESCRIPTION
This pull request the following dependencies:

* Axon Framework = 4.7.1
* AMQP Extension = 4.7.1
* JGroups Extension = 4.7.0
* Kafka Extension = 4.7.0
* Kotlin Extension = 4.7.0
* Mongo Extension = 4.7.0
* Multi-Tenancy Extension = 4.7.0
* Reactor Extension = 4.7.0
* Spring Cloud Extension = 4.7.0
* Tracing Extension = 4.7.0

Furthermore, the Jakarta modules are removed since they've been removed from the Framework in favor of providing Legacy Javax and Jakarta classes.

In doing the above, this pull request resolves #112