### PR TITLE
Upgrade Axon Server Connector Java to 2023.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </issueManagement>
 
     <properties>
-        <axonserver-connector-java.version>2023.1.1</axonserver-connector-java.version>
+        <axonserver-connector-java.version>2023.2.0</axonserver-connector-java.version>
         <axon.version>4.9.0</axon.version>
       
         <axonserver-plugin-api.version>4.6.0</axonserver-plugin-api.version>


### PR DESCRIPTION
This pull request upgrades the `axonserver-connector-java` dependency to the latest, which is 2023.2.0.

Note that the new version of `axonserver-connector-java` ensures the compatibility between the connector and Spring Boot 3.1.6 and up is restored due to an adjustment in the gRPC and netty dependencies.