### PR TITLE
Update the Multi Tenancy extension to 4.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <extension.kafka.version>4.10.0</extension.kafka.version>
         <extension.kotlin.version>4.10.0</extension.kotlin.version>
         <extension.mongo.version>4.10.0</extension.mongo.version>
-        <extension.multitenancy.version>4.10.0</extension.multitenancy.version>
+        <extension.multitenancy.version>4.10.2</extension.multitenancy.version>
         <extension.reactor.version>4.10.0</extension.reactor.version>
         <extension.spring-aot.version>4.10.0</extension.spring-aot.version>
         <extension.springcloud.version>4.10.0</extension.springcloud.version>


### PR DESCRIPTION
This PR updates the `axon-multitenancy` extension version from 4.10.0 to 4.10.2.