### PR TITLE
Update Axon Framework and extensions to 4.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2024. Axon Framework
+  ~ Copyright (c) 2010-2025. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -42,22 +42,22 @@
 
     <properties>
         <axonserver-connector-java.version>2024.1.1</axonserver-connector-java.version>
-        <axon.version>4.10.3</axon.version>
+        <axon.version>4.11.0</axon.version>
       
         <axonserver-plugin-api.version>4.8.1</axonserver-plugin-api.version>
 
-        <extension.amqp.version>4.10.0</extension.amqp.version>
+        <extension.amqp.version>4.11.0</extension.amqp.version>
         <extension.cdi.version>4.5-alpha1</extension.cdi.version>
-        <extension.jgroups.version>4.10.0</extension.jgroups.version>
-        <extension.jobrunrpro.version>4.10.0</extension.jobrunrpro.version>
-        <extension.kafka.version>4.10.0</extension.kafka.version>
-        <extension.kotlin.version>4.10.0</extension.kotlin.version>
-        <extension.mongo.version>4.10.0</extension.mongo.version>
-        <extension.multitenancy.version>4.10.3</extension.multitenancy.version>
-        <extension.reactor.version>4.10.0</extension.reactor.version>
-        <extension.spring-aot.version>4.10.1</extension.spring-aot.version>
-        <extension.springcloud.version>4.10.0</extension.springcloud.version>
-        <extension.tracing.version>4.10.0</extension.tracing.version>
+        <extension.jgroups.version>4.11.0</extension.jgroups.version>
+        <extension.jobrunrpro.version>4.11.0</extension.jobrunrpro.version>
+        <extension.kafka.version>4.11.0</extension.kafka.version>
+        <extension.kotlin.version>4.11.0</extension.kotlin.version>
+        <extension.mongo.version>4.11.0</extension.mongo.version>
+        <extension.multitenancy.version>4.11.0</extension.multitenancy.version>
+        <extension.reactor.version>4.11.0</extension.reactor.version>
+        <extension.spring-aot.version>4.11.0</extension.spring-aot.version>
+        <extension.springcloud.version>4.11.0</extension.springcloud.version>
+        <extension.tracing.version>4.11.0</extension.tracing.version>
 
         <projectreactor.version>3.7.2</projectreactor.version>
 


### PR DESCRIPTION
Update Axon Framework and extensions to 4.11.0. Furthermore, this PR updates the Axon Server Connector for Java version to 2024.2.2.

With this in place, we are ready to release BOM 4.11.0 as well.