### PR TITLE
Upgrade Axon Framework + all Extensions to 4.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,22 +42,22 @@
 
     <properties>
         <axonserver-connector-java.version>2024.2.4</axonserver-connector-java.version>
-        <axon.version>4.11.3</axon.version>
+        <axon.version>4.12.0</axon.version>
       
         <axonserver-plugin-api.version>4.10.0</axonserver-plugin-api.version>
 
-        <extension.amqp.version>4.11.0</extension.amqp.version>
+        <extension.amqp.version>4.12.0</extension.amqp.version>
         <extension.cdi.version>4.5-alpha1</extension.cdi.version>
-        <extension.jgroups.version>4.11.0</extension.jgroups.version>
-        <extension.jobrunrpro.version>4.11.0</extension.jobrunrpro.version>
-        <extension.kafka.version>4.11.1</extension.kafka.version>
-        <extension.kotlin.version>4.11.1</extension.kotlin.version>
-        <extension.mongo.version>4.11.1</extension.mongo.version>
-        <extension.multitenancy.version>4.11.0</extension.multitenancy.version>
-        <extension.reactor.version>4.11.0</extension.reactor.version>
-        <extension.spring-aot.version>4.11.0</extension.spring-aot.version>
-        <extension.springcloud.version>4.11.0</extension.springcloud.version>
-        <extension.tracing.version>4.11.0</extension.tracing.version>
+        <extension.jgroups.version>4.12.0</extension.jgroups.version>
+        <extension.jobrunrpro.version>4.12.0</extension.jobrunrpro.version>
+        <extension.kafka.version>4.12.0</extension.kafka.version>
+        <extension.kotlin.version>4.12.0</extension.kotlin.version>
+        <extension.mongo.version>4.12.0</extension.mongo.version>
+        <extension.multitenancy.version>4.12.0</extension.multitenancy.version>
+        <extension.reactor.version>4.12.0</extension.reactor.version>
+        <extension.spring-aot.version>4.12.0</extension.spring-aot.version>
+        <extension.springcloud.version>4.12.0</extension.springcloud.version>
+        <extension.tracing.version>4.12.0</extension.tracing.version>
 
         <projectreactor.version>3.7.8</projectreactor.version>
 


### PR DESCRIPTION
This pull request upgrades the versions of Axon Framework and **all** Axon Framework Extensions from 4.11.x to 4.12.0.