### PR TITLE
Upgrade Axon Framework to 4.13.0 and Axon Server Connector for Java to 2025.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <axonserver-connector-java.version>2025.2.1</axonserver-connector-java.version>
-        <axon.version>4.12.3</axon.version>
+        <axon.version>4.13.0</axon.version>
       
         <axonserver-plugin-api.version>4.10.0</axonserver-plugin-api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </issueManagement>
 
     <properties>
-        <axonserver-connector-java.version>2024.2.5</axonserver-connector-java.version>
+        <axonserver-connector-java.version>2025.2.1</axonserver-connector-java.version>
         <axon.version>4.12.3</axon.version>
       
         <axonserver-plugin-api.version>4.10.0</axonserver-plugin-api.version>


### PR DESCRIPTION
This pull request upgrades two version:

1. Axon Framework to 4.13.0
2. Axon Server Connector for Java to 2025.2.1